### PR TITLE
Keep "SetUp" PGN tag

### DIFF
--- a/src/game/PGNHelpers.ts
+++ b/src/game/PGNHelpers.ts
@@ -9,6 +9,7 @@ const PGN_KEYS_TO_SHORT = {
   Date: "D",
   Result: "R",
   FEN: "F",
+  SetUp: "SU",
   WhiteElo: "WE",
   BlackElo: "BE",
 };


### PR DESCRIPTION
Include the "SetUp" tag when importing PGN. The tag is necessary (along with "FEN") to correctly import a game from a custom starting position. For example, the game at https://lichess.org/cU1M8dKA renders incorrectly without this change.

I'm arbitrarily proposing "SU" as the tag's short form. Anything else is fine, of course.