### PR TITLE
Allow missing SetUp tag when FEN tag is present

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@arrows/array": "^1.4.1",
-    "chess.js": "^0.12.0",
+    "chess.js": "^0.13.2",
     "common-tags": "^1.8.2",
     "gif.js": "^0.2.0",
     "h264-mp4-encoder": "^1.0.12",

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -29,7 +29,7 @@ class Game {
     const game = new Chess();
     const replay = new Chess();
 
-    game.load_pgn(cleanPGN(pgn));
+    game.load_pgn(cleanPGN(pgn), { sloppy: true });
     game.delete_comments();
 
     const moves = game.history({ verbose: true });

--- a/src/game/PGNHelpers.ts
+++ b/src/game/PGNHelpers.ts
@@ -22,7 +22,7 @@ const PGN_KEYS_TO_LONG = Object.fromEntries(
 
 const cleanPGN = (pgn: string) => {
   const game = new Chess();
-  game.load_pgn(pgn);
+  game.load_pgn(pgn, { sloppy: true });
   game.delete_comments();
 
   if (!game.header().Result) {

--- a/src/game/PGNHelpers.ts
+++ b/src/game/PGNHelpers.ts
@@ -9,7 +9,6 @@ const PGN_KEYS_TO_SHORT = {
   Date: "D",
   Result: "R",
   FEN: "F",
-  SetUp: "SU",
   WhiteElo: "WE",
   BlackElo: "BE",
 };


### PR DESCRIPTION
Accept PGN text that has an `FEN` tag but no `SetUp` tag. Strict PGN importing calls for the `FEN` tag to be ignored unless the header contains `[SetUp "1"]`. The `sloppy` option causes the Chess.js library to [allow](https://github.com/jhlywa/chess.js/blob/35e3fbfbafce1295e386ccc160ddf368278f4ad8/chess.js#L1677-L1684) the absent `SetUp` tag.

The current behavior is that the parser ignores the `FEN` tag and defaults to the standard starting position. It tries to apply the listed moves to that position and cuts the game off after the first illegal move. ShareChess correctly shows the custom initial position, but the moves remain cut off.

This issue comes up in practice, for instance, when using Lichess's [board editor](https://lichess.org/editor) and then going to the [analysis](https://lichess.org/analysis) page. The PGN box at the bottom of the analysis page includes `FEN` but not `SetUp`. Here is some sample PGN text as exported from that box:
```
[Variant "From Position"]
[FEN "rnbq1rk1/pppn1ppp/4p3/3pP3/1b1P4/2NB1N2/PPP2PPP/R1BQK2R w KQ - 0 1"]

1. Bxh7+ Kxh7 2. Ng5+ Qxg5 3. Bxg5
```

From grepping around `chess.js`, it looks like the "sloppy" option causes the parser to accept several other deviations from standard PGN, which could provide some additional convenience to users who use affected tools.

Coincidentally, this fix depends on a [change](https://github.com/jhlywa/chess.js/commit/35e3fbfbafce1295e386ccc160ddf368278f4ad8) in the Chess.js library from only 10 days ago. This pull request includes a version bump of the `chess.js` dependency. I'll leave it up to the maintainer if you want to commit `package-lock.json` changes. (AFAICT it's out of sync already -- a bunch of extra stuff changes when I do `npm install`. Pardon my ignorance, I don't do a lot of Node work.)