### PR TITLE
Avoid template overriding in Stylus

### DIFF
--- a/scripts/createBoardsStylesheets.ts
+++ b/scripts/createBoardsStylesheets.ts
@@ -91,7 +91,7 @@ const loadStyle = async (name: string) =>
 const Header = (boardName: string, content: string) => {
 	return `
     /* ==UserStyle==
-    @name           Custom chessboard
+    @name           Custom chessboard ${Math.floor(Math.random() * 99999999)}
     @namespace      sharechess.github.io
     @version        1.7.0
     @description    ${boardName} chessboard for ${domains

--- a/scripts/createPiecesStylesheets.ts
+++ b/scripts/createPiecesStylesheets.ts
@@ -106,7 +106,7 @@ const Header = (setName: string, content: string, shadows: boolean = false) => {
 
   return `
     /* ==UserStyle==
-    @name           Custom pieces
+    @name           Custom pieces ${Math.floor(Math.random() * 99999999)}
     @namespace      sharechess.github.io
     @version        1.5.0
     @description    ${namePretty} piece set for ${domains


### PR DESCRIPTION
Appending a random number between 0 and 99,999,998 (a total of 99,999,999 possible values) to the `@name` directive allows users to save multiple templates in Stylus without encountering naming conflicts. This approach does not guarantee uniqueness in every case but the probability of a collision is negligible. For example, if a user creates up to 100 templates, the probability of a collision is approximately 0.00005%. This level of uniqueness should be sufficient for the intended use case.
_Resolves issue #8_